### PR TITLE
feat: use genesis key in network set command 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,15 +3166,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "sn_api"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d252052a61df6b1a58ae2a15d4f630adc447487f7c8b277e292e1eeef130f9"
+checksum = "0a18060c42e4b0c8d8436ef989fd67b35bbb4b4792e46b1baf9d487aa301fc1e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.33.8"
+version = "0.34.0"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",
@@ -3256,6 +3256,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "walkdir",
  "xor_name 2.0.0",
  "xor_name 3.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ structopt = "~0.3"
 tracing = "~0.1.26"
 tracing-appender = "~0.1.2"
 tracing-subscriber = "~0.2.15"
+url = "2.2.2"
 xor_name = "3.0.0"
 
   [dependencies.bls]

--- a/src/operations/auth_and_connect.rs
+++ b/src/operations/auth_and_connect.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::config::read_current_node_config;
+use super::config::Config;
 use crate::{APP_ID, APP_NAME, APP_VENDOR};
 use color_eyre::{eyre::eyre, eyre::WrapErr, Result};
 use sn_api::{Keypair, Safe};
@@ -47,7 +47,7 @@ pub async fn authorise_cli(endpoint: Option<String>, is_self_authing: bool) -> R
 // otherwise it creates a read only connection.
 // Returns the app's keypair if connection was succesfully made with credentials,
 // otherwise it returns 'None' if conneciton is read only.
-pub async fn connect(safe: &mut Safe) -> Result<Option<Keypair>> {
+pub async fn connect(safe: &mut Safe, config: Config) -> Result<Option<Keypair>> {
     debug!("Connecting...");
 
     let app_keypair = if let Ok((_, keypair)) = read_credentials() {
@@ -61,7 +61,7 @@ pub async fn connect(safe: &mut Safe) -> Result<Option<Keypair>> {
         info!("No credentials found for CLI, connecting with read-only access...");
     }
 
-    let (_, bootstrap_contacts) = read_current_node_config()?;
+    let (_, bootstrap_contacts) = config.read_current_node_config()?;
     let client_cfg = client_config_path();
     match safe
         .connect(

--- a/src/operations/config.rs
+++ b/src/operations/config.rs
@@ -7,35 +7,35 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Result};
+use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Help, Result};
 use prettytable::Table;
 use serde::{Deserialize, Serialize};
 use sn_api::{NodeConfig, PublicKey};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
-    fs::{self, create_dir_all, remove_file},
+    fs::{self, remove_file},
     net::SocketAddr,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use tracing::debug;
 
-const CONFIG_FILENAME: &str = "config.json";
 const CONFIG_NETWORKS_DIRNAME: &str = "networks";
 
 #[derive(Deserialize, Debug, Serialize, Clone)]
 pub enum NetworkInfo {
-    /// A list of IPv4 addresses wich are the contact peers of the network
-    Addresses(NodeConfig),
-    /// A URL where the network connection information can be fetched/read from
-    ConnInfoUrl(String),
+    /// The node configuration is a genesis key, which is a BLS public key, and a set of nodes
+    /// participating in the network, which are an IPv4 and port address pair.
+    NodeConfig(NodeConfig),
+    /// A URL or file path where the network connection information can be fetched/read from.
+    ConnInfoLocation(String),
 }
 
 impl fmt::Display for NetworkInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Addresses(addresses) => write!(f, "{:?}", addresses),
-            Self::ConnInfoUrl(url) => write!(f, "{}", url),
+            Self::NodeConfig(addresses) => write!(f, "{:?}", addresses),
+            Self::ConnInfoLocation(url) => write!(f, "{}", url),
         }
     }
 }
@@ -43,72 +43,96 @@ impl fmt::Display for NetworkInfo {
 impl NetworkInfo {
     pub async fn matches(&self, node_config: &NodeConfig) -> bool {
         match self {
-            Self::Addresses(nc) => node_config == nc,
-            Self::ConnInfoUrl(config_location) => match retrieve_node_config(config_location).await
-            {
-                Ok(info) => info == *node_config,
-                Err(_) => false,
-            },
+            Self::NodeConfig(nc) => nc == node_config,
+            Self::ConnInfoLocation(config_location) => {
+                match retrieve_node_config(config_location).await {
+                    Ok(info) => info == *node_config,
+                    Err(_) => false,
+                }
+            }
         }
     }
 }
 
-#[derive(Deserialize, Debug, Serialize, Default)]
+#[derive(Clone, Deserialize, Debug, Serialize, Default)]
 pub struct Settings {
     networks: BTreeMap<String, NetworkInfo>,
-    // contacts: BTreeMap<String, String>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Config {
     settings: Settings,
-    file_path: PathBuf,
+    cli_config_path: PathBuf,
+    node_config_path: PathBuf,
 }
 
 impl Config {
-    pub fn read() -> Result<Self> {
-        let file_path = config_file_path()?;
+    pub fn new(cli_config_path: PathBuf, node_config_path: PathBuf) -> Result<Config> {
+        let mut pb = cli_config_path.clone();
+        pb.pop();
+        std::fs::create_dir_all(pb.as_path())?;
 
-        let config = if !file_path.exists() {
-            let empty_config = Self {
-                settings: Settings::default(),
-                file_path: file_path.clone(),
-            };
-            empty_config.write_settings_to_file().wrap_err_with(|| {
-                format!("Unable to create config at '{}'", file_path.display(),)
-            })?;
-            debug!("Empty config file created at '{}'", file_path.display(),);
-            empty_config
-        } else {
-            let file = fs::File::open(&file_path).wrap_err_with(|| {
-                format!("Error opening config file from '{}'", file_path.display(),)
-            })?;
-
-            let settings: Settings = serde_json::from_reader(file).wrap_err_with(|| {
+        let settings: Settings;
+        if cli_config_path.exists() {
+            let file = fs::File::open(&cli_config_path).wrap_err_with(|| {
                 format!(
-                    "Format of the config file at '{}' is not valid and couldn't be parsed",
-                    file_path.display()
+                    "Error opening config file from '{}'",
+                    cli_config_path.display(),
                 )
             })?;
-
+            settings = serde_json::from_reader(file).wrap_err_with(|| {
+                format!(
+                    "Format of the config file at '{}' is not valid and couldn't be parsed",
+                    cli_config_path.display()
+                )
+            })?;
             debug!(
                 "Config settings retrieved from '{}': {:?}",
-                file_path.display(),
+                cli_config_path.display(),
                 settings
             );
+        } else {
+            settings = Settings::default();
+            debug!(
+                "Empty config file created at '{}'",
+                cli_config_path.display()
+            );
+        }
 
-            Self {
-                settings,
-                file_path,
-            }
+        let config = Config {
+            settings,
+            cli_config_path: cli_config_path.clone(),
+            node_config_path,
         };
-
+        config.write_settings_to_file().wrap_err_with(|| {
+            format!("Unable to create config at '{}'", cli_config_path.display())
+        })?;
         Ok(config)
+    }
+
+    pub fn read_current_node_config(&self) -> Result<(PathBuf, NodeConfig)> {
+        let current_conn_info = fs::read(&self.node_config_path).wrap_err_with(|| {
+            eyre!("There doesn't seem to be any node configuration setup in your system.")
+                .suggestion(
+                    "A node config will be created if you join a network or launch your own.",
+                )
+        })?;
+        let node_config = deserialise_node_config(&current_conn_info).wrap_err_with(|| {
+            eyre!(format!(
+                "Unable to read current network connection information from '{}'.",
+                self.node_config_path.display()
+            ))
+            .suggestion(
+                "This file is likely not a node configuration file.\
+                Please point towards another file with a valid node configuration.",
+            )
+        })?;
+        Ok((self.node_config_path.clone(), node_config))
     }
 
     pub async fn get_network_info(&self, name: &str) -> Result<NodeConfig> {
         match self.settings.networks.get(name) {
-            Some(NetworkInfo::ConnInfoUrl(config_location)) => {
+            Some(NetworkInfo::ConnInfoLocation(config_location)) => {
                 println!(
                     "Fetching '{}' network connection information from '{}' ...",
                     name, config_location
@@ -117,7 +141,7 @@ impl Config {
                 let node_config = retrieve_node_config(config_location).await?;
                 Ok(node_config)
             },
-            Some(NetworkInfo::Addresses(addresses)) => Ok(addresses.clone()),
+            Some(NetworkInfo::NodeConfig(addresses)) => Ok(addresses.clone()),
             None => bail!("No network with name '{}' was found in the config. Please use the networks 'add'/'set' subcommand to add it", name)
         }
     }
@@ -135,15 +159,36 @@ impl Config {
             info
         } else {
             // Cache current network connection info
-            let (_, conn_info) = read_current_node_config()?;
-            let cache_path = cache_node_config(name, &conn_info)?;
+            let (_, node_config) = self.read_current_node_config()?;
+            let cache_path = self.cache_node_config(name, &node_config)?;
             println!(
                 "Caching current network connection information into '{}'",
                 cache_path.display()
             );
-            NetworkInfo::ConnInfoUrl(cache_path.display().to_string())
+            NetworkInfo::ConnInfoLocation(cache_path.display().to_string())
         };
 
+        match &net_info {
+            NetworkInfo::NodeConfig(_) => {}
+            NetworkInfo::ConnInfoLocation(location) => {
+                let result = url::Url::parse(location);
+                if result.is_err() {
+                    // The location is not a valid URL, so try and parse it as a file.
+                    let pb = PathBuf::from(Path::new(&location));
+                    if !pb.is_file() {
+                        return Err(eyre!("The config location must use an existing file path.")
+                            .suggestion(
+                                "Please choose an existing file with a network configuration.",
+                            ));
+                    }
+                    deserialise_node_config(&fs::read(pb.as_path())?).wrap_err_with(|| {
+                        eyre!("The file must contain a valid network configuration.").suggestion(
+                            "Please choose another file with a valid network configuration.",
+                        )
+                    })?;
+                }
+            }
+        }
         self.settings
             .networks
             .insert(name.to_string(), net_info.clone());
@@ -156,11 +201,12 @@ impl Config {
 
     pub fn remove_network(&mut self, name: &str) -> Result<()> {
         match self.settings.networks.remove(name) {
-            Some(NetworkInfo::ConnInfoUrl(location)) => {
+            Some(NetworkInfo::ConnInfoLocation(location)) => {
                 self.write_settings_to_file()?;
                 debug!("Network '{}' removed from config", name);
                 println!("Network '{}' was removed from the config", name);
-                let mut config_local_path = get_cli_config_path()?;
+                let mut config_local_path = self.cli_config_path.clone();
+                config_local_path.pop();
                 config_local_path.push(CONFIG_NETWORKS_DIRNAME);
                 if PathBuf::from(&location).starts_with(config_local_path) {
                     println!(
@@ -176,7 +222,7 @@ impl Config {
                     }
                 }
             }
-            Some(NetworkInfo::Addresses(_)) => {
+            Some(NetworkInfo::NodeConfig(_)) => {
                 self.write_settings_to_file()?;
                 debug!("Network '{}' removed from config", name);
                 println!("Network '{}' was removed from the config", name);
@@ -193,20 +239,21 @@ impl Config {
     }
 
     pub async fn switch_to_network(&self, name: &str) -> Result<()> {
-        let (base_path, file_path) = get_current_network_info_path()?;
+        let mut base_path = self.node_config_path.clone();
+        base_path.pop();
 
         if !base_path.exists() {
             println!(
                 "Creating '{}' folder for network connection info",
                 base_path.display()
             );
-            create_dir_all(&base_path)
+            std::fs::create_dir_all(&base_path)
                 .wrap_err("Couldn't create folder for network connection info")?;
         }
 
         let contacts = self.get_network_info(name).await?;
         let conn_info = serialise_node_config(&contacts)?;
-        fs::write(&file_path, conn_info).wrap_err_with(|| {
+        fs::write(&self.node_config_path, conn_info).wrap_err_with(|| {
             format!(
                 "Unable to write network connection info in '{}'",
                 base_path.display(),
@@ -218,7 +265,7 @@ impl Config {
         let mut table = Table::new();
         table.add_row(row![bFg->"Networks"]);
         table.add_row(row![bFg->"Current", bFg->"Network name", bFg->"Connection info"]);
-        let current_node_config = match read_current_node_config() {
+        let current_node_config = match self.read_current_node_config() {
             Ok((_, current_conn_info)) => Some(current_conn_info),
             Err(_) => None, // we simply ignore the error, none of the networks is currently active/set in the system
         };
@@ -236,85 +283,44 @@ impl Config {
         table.printstd();
     }
 
+    //
     // Private helpers
+    //
+    fn cache_node_config(&self, network_name: &str, node_config: &NodeConfig) -> Result<PathBuf> {
+        let mut pb = self.cli_config_path.clone();
+        pb.pop();
+        pb.push(CONFIG_NETWORKS_DIRNAME);
+        if !pb.exists() {
+            println!(
+                "Creating '{}' folder for networks connection info cache",
+                pb.display()
+            );
+            std::fs::create_dir_all(&pb)
+                .wrap_err("Couldn't create folder for networks information cache")?;
+        }
+
+        pb.push(format!("{}_node_connection_info.config", network_name));
+        let conn_info = serialise_node_config(node_config)?;
+        fs::write(&pb, conn_info)?;
+        Ok(pb)
+    }
 
     fn write_settings_to_file(&self) -> Result<()> {
         let serialised_settings = serde_json::to_string(&self.settings)
             .wrap_err("Failed to serialise config settings")?;
-
-        fs::write(&self.file_path, serialised_settings.as_bytes()).wrap_err_with(|| {
+        fs::write(&self.cli_config_path, serialised_settings.as_bytes()).wrap_err_with(|| {
             format!(
                 "Unable to write config settings to '{}'",
-                self.file_path.display()
+                self.cli_config_path.display()
             )
         })?;
-
         debug!(
             "Config settings at '{}' updated with: {:?}",
-            self.file_path.display(),
+            self.cli_config_path.display(),
             self.settings
         );
-
         Ok(())
     }
-}
-
-pub fn read_current_node_config() -> Result<(PathBuf, NodeConfig)> {
-    let (_, file_path) = get_current_network_info_path()?;
-    let current_conn_info = fs::read(&file_path).wrap_err_with(||
-        format!(
-            "There doesn't seem to be a any network setup in your system. Unable to read current network connection information from '{}'",
-            file_path.display()
-        )
-    )?;
-
-    let node_config = deserialise_node_config(&current_conn_info).wrap_err_with(|| {
-        format!(
-            "Unable to read current network connection information from '{}'",
-            file_path.display()
-        )
-    })?;
-
-    Ok((file_path, node_config))
-}
-
-fn config_file_path() -> Result<PathBuf> {
-    let config_local_path = get_cli_config_path()?;
-    let file_path = config_local_path.join(CONFIG_FILENAME);
-    if !config_local_path.exists() {
-        println!(
-            "Creating '{}' folder for config file",
-            config_local_path.display()
-        );
-        create_dir_all(config_local_path)
-            .wrap_err("Couldn't create project's local config folder")?;
-    }
-
-    Ok(file_path)
-}
-
-fn cache_node_config(network_name: &str, contacts: &NodeConfig) -> Result<PathBuf> {
-    let mut file_path = get_cli_config_path()?;
-    file_path.push(CONFIG_NETWORKS_DIRNAME);
-    if !file_path.exists() {
-        println!(
-            "Creating '{}' folder for networks connection info cache",
-            file_path.display()
-        );
-        create_dir_all(&file_path)
-            .wrap_err("Couldn't create folder for networks information cache")?;
-    }
-
-    file_path.push(format!("{}_node_connection_info.config", network_name));
-    let conn_info = serialise_node_config(contacts)?;
-    fs::write(&file_path, conn_info).wrap_err_with(|| {
-        format!(
-            "Unable to cache connection information in '{}'",
-            file_path.display(),
-        )
-    })?;
-
-    Ok(file_path)
 }
 
 async fn retrieve_node_config(location: &str) -> Result<NodeConfig> {
@@ -346,8 +352,7 @@ async fn retrieve_node_config(location: &str) -> Result<NodeConfig> {
 }
 
 fn deserialise_node_config(bytes: &[u8]) -> Result<NodeConfig> {
-    let deserialized: (String, BTreeSet<SocketAddr>) = serde_json::from_slice(bytes)
-        .wrap_err_with(|| "Format of the contacts addresses is not valid and couldn't be parsed")?;
+    let deserialized: (String, BTreeSet<SocketAddr>) = serde_json::from_slice(bytes)?;
     let genesis_key = PublicKey::bls_from_hex(&deserialized.0)?
         .bls()
         .ok_or_else(|| eyre!("Unexpectedly failed to obtain (BLS) genesis key."))?;
@@ -360,24 +365,638 @@ pub fn serialise_node_config(node_config: &NodeConfig) -> Result<String> {
         .wrap_err_with(|| "Failed to serialise network connection info")
 }
 
-fn get_current_network_info_path() -> Result<(PathBuf, PathBuf)> {
-    let mut node_data_path =
-        dirs_next::home_dir().ok_or_else(|| eyre!("Failed to obtain user's home path"))?;
+#[cfg(test)]
+mod constructor {
+    use super::{Config, NetworkInfo};
+    use assert_fs::prelude::*;
+    use color_eyre::{eyre::eyre, Result};
+    use predicates::prelude::*;
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
 
-    node_data_path.push(".safe");
-    node_data_path.push("node");
+    #[test]
+    fn fields_should_be_set_to_correct_values() -> Result<()> {
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = tmp_dir.child(".safe/cli/config.json");
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
 
-    Ok((
-        node_data_path.clone(),
-        node_data_path.join("node_connection_info.config"),
-    ))
+        let config = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        assert_eq!(config.cli_config_path, cli_config_file.path());
+        assert_eq!(config.node_config_path, node_config_file.path());
+        assert_eq!(config.settings.networks.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn cli_config_directory_should_be_created() -> Result<()> {
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let cli_config_dir = tmp_dir.child(".safe/cli");
+        let cli_config_file = cli_config_dir.child("config.json");
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
+
+        let _ = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        cli_config_dir.assert(predicate::path::is_dir());
+        Ok(())
+    }
+
+    #[test]
+    fn given_config_file_does_not_exist_then_it_should_be_created() -> Result<()> {
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = tmp_dir.child(".safe/cli/config.json");
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
+        let _ = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        cli_config_file.assert(predicate::path::exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn given_config_file_exists_then_the_settings_should_be_read() -> Result<()> {
+        let serialized_config = r#"
+        {
+            "networks": {
+                "existing_network": {
+                    "NodeConfig":[
+                        [140,44,196,143,12,92,218,53,190,33,205,167,109,183,94,205,16,140,197,200,96,112,136,218,221,16,57,54,204,60,58,93,199,119,26,17,105,232,33,188,163,194,145,223,194,95,92,54],
+                        ["127.0.0.1:12000","127.0.0.2:12000"]
+                    ]
+                }
+            }
+        }"#;
+        let tmp_dir = assert_fs::TempDir::new()?.into_persistent();
+        let cli_config_file = tmp_dir.child(".safe/cli/config.json");
+        cli_config_file.write_str(serialized_config)?;
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
+        let config = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        let (network_name, network_info) = config
+            .networks_iter()
+            .next()
+            .ok_or_else(|| eyre!("failed to obtain item from networks list"))?;
+        assert_eq!(config.networks_iter().count(), 1);
+        assert_eq!(network_name, "existing_network");
+        match network_info {
+            NetworkInfo::NodeConfig((_, contacts)) => {
+                assert_eq!(contacts.len(), 2);
+
+                let node: SocketAddr = "127.0.0.1:12000".parse().unwrap();
+                assert_eq!(contacts.get(&node), Some(&node));
+                let node: SocketAddr = "127.0.0.2:12000".parse().unwrap();
+                assert_eq!(contacts.get(&node), Some(&node));
+            }
+            NetworkInfo::ConnInfoLocation(_) => {
+                return Err(eyre!("connection info doesn't apply to this test"));
+            }
+        }
+
+        Ok(())
+    }
 }
 
-fn get_cli_config_path() -> Result<PathBuf> {
-    let mut project_data_path =
-        dirs_next::home_dir().ok_or_else(|| eyre!("Couldn't find user's home directory"))?;
-    project_data_path.push(".safe");
-    project_data_path.push("cli");
+#[cfg(test)]
+mod read_current_node_config {
+    use super::Config;
+    use assert_fs::prelude::*;
+    use color_eyre::Result;
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
 
-    Ok(project_data_path)
+    #[test]
+    fn given_existing_node_config_then_it_should_be_read() -> Result<()> {
+        let genesis_key_hex = "89505bbfcac9335a7639a1dca9ed027b98be46b03953e946e53695f678c827f18f6fc22dc888de2bce9078f3fce55095";
+        let serialized_node_config = r#"
+        [
+            "89505bbfcac9335a7639a1dca9ed027b98be46b03953e946e53695f678c827f18f6fc22dc888de2bce9078f3fce55095",
+            [
+                "127.0.0.1:33314",
+                "127.0.0.1:38932",
+                "127.0.0.1:39132",
+                "127.0.0.1:47795",
+                "127.0.0.1:49976",
+                "127.0.0.1:53018",
+                "127.0.0.1:53421",
+                "127.0.0.1:54002",
+                "127.0.0.1:54386",
+                "127.0.0.1:55890",
+                "127.0.0.1:57956"
+            ]
+        ]"#;
+
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = tmp_dir.child(".safe/cli/config.json");
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
+        node_config_file.write_str(serialized_node_config)?;
+        let config = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        let (node_config_path, node_config) = config.read_current_node_config()?;
+
+        let genesis_key = node_config.0;
+        let retrieved_genesis_key_hex = hex::encode(genesis_key.to_bytes());
+        let nodes = node_config.1;
+        assert_eq!(genesis_key_hex, retrieved_genesis_key_hex);
+        assert_eq!(node_config_file.path(), node_config_path);
+        assert_eq!(nodes.len(), 11);
+
+        let node: SocketAddr = "127.0.0.1:33314".parse().unwrap();
+        assert_eq!(nodes.get(&node), Some(&node));
+
+        Ok(())
+    }
+
+    #[test]
+    fn given_no_existing_node_config_file_the_result_should_be_an_error() -> Result<()> {
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = tmp_dir.child(".safe/cli/config.json");
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
+        let config = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        let result = config.read_current_node_config();
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "There doesn't seem to be any node configuration setup in your system."
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn given_node_config_path_points_to_non_node_config_file_the_result_should_be_an_error(
+    ) -> Result<()> {
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = tmp_dir.child(".safe/cli/config.json");
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
+        node_config_file.write_str("this is not a node config file")?;
+        let config = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        let result = config.read_current_node_config();
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!(
+                "Unable to read current network connection information from '{}'.",
+                node_config_file.path().display()
+            )
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod add_network {
+    use super::{Config, NetworkInfo};
+    use assert_fs::prelude::*;
+    use color_eyre::{eyre::eyre, Result};
+    use predicates::prelude::*;
+    use std::collections::BTreeSet;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::path::PathBuf;
+
+    #[test]
+    fn given_network_info_not_supplied_then_current_network_config_will_be_cached() -> Result<()> {
+        let serialized_node_config = r#"
+        [
+            "89505bbfcac9335a7639a1dca9ed027b98be46b03953e946e53695f678c827f18f6fc22dc888de2bce9078f3fce55095",
+            [
+                "127.0.0.1:33314",
+                "127.0.0.1:38932",
+                "127.0.0.1:39132",
+                "127.0.0.1:47795",
+                "127.0.0.1:49976",
+                "127.0.0.1:53018",
+                "127.0.0.1:53421",
+                "127.0.0.1:54002",
+                "127.0.0.1:54386",
+                "127.0.0.1:55890",
+                "127.0.0.1:57956"
+            ]
+        ]"#;
+
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = tmp_dir.child(".safe/cli/config.json");
+        let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
+        let new_network_file =
+            tmp_dir.child(".safe/cli/networks/new_network_node_connection_info.config");
+        node_config_file.write_str(serialized_node_config)?;
+        let mut config = Config::new(
+            PathBuf::from(cli_config_file.path()),
+            PathBuf::from(node_config_file.path()),
+        )?;
+
+        let result = config.add_network("new_network", None);
+
+        assert!(result.is_ok());
+        new_network_file.assert(predicate::path::is_file());
+
+        let network = config.networks_iter().next().unwrap();
+        let network_name = network.0;
+        let network_info = network.1;
+        assert_eq!(network_name, "new_network");
+        match network_info {
+            NetworkInfo::NodeConfig(_) => {
+                return Err(eyre!("node config doesn't apply to this test"));
+            }
+            NetworkInfo::ConnInfoLocation(path) => {
+                assert_eq!(
+                    *path,
+                    String::from(new_network_file.path().to_str().unwrap())
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn given_no_pre_existing_config_and_a_file_path_is_used_then_a_network_should_be_saved(
+    ) -> Result<()> {
+        let existing_node_config = r#"
+        [
+          "89505bbfcac9335a7639a1dca9ed027b98be46b03953e946e53695f678c827f18f6fc22dc888de2bce9078f3fce55095",
+          [
+            "127.0.0.1:33314",
+            "127.0.0.1:38932",
+            "127.0.0.1:39132",
+            "127.0.0.1:47795",
+            "127.0.0.1:49976",
+            "127.0.0.1:53018",
+            "127.0.0.1:53421",
+            "127.0.0.1:54002",
+            "127.0.0.1:54386",
+            "127.0.0.1:55890",
+            "127.0.0.1:57956"
+          ]
+        ]"#;
+
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child("saved_connection_info.config");
+        node_config_file.write_str(existing_node_config)?;
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+
+        let result = config.add_network(
+            "new_network",
+            Some(NetworkInfo::ConnInfoLocation(String::from(
+                node_config_file.path().to_str().unwrap(),
+            ))),
+        );
+
+        assert!(result.is_ok());
+        cli_config_file.assert(predicate::path::is_file());
+
+        assert_eq!(config.networks_iter().count(), 1);
+
+        let network = config.networks_iter().next().unwrap();
+        let network_name = network.0;
+        let network_info = network.1;
+        assert_eq!(network_name, "new_network");
+        match network_info {
+            NetworkInfo::NodeConfig(_) => {
+                eyre!("node config doesn't apply to this test");
+            }
+            NetworkInfo::ConnInfoLocation(path) => {
+                assert_eq!(
+                    *path,
+                    String::from(node_config_file.path().to_str().unwrap())
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn given_no_pre_existing_config_and_a_non_existent_file_path_is_used_then_the_result_should_be_an_error(
+    ) -> Result<()> {
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child(".safe/node/node_connection_info.config");
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+
+        let result = config.add_network(
+            "new_network",
+            Some(NetworkInfo::ConnInfoLocation(String::from(
+                node_config_file.path().to_str().unwrap(),
+            ))),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "The config location must use an existing file path."
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn given_no_pre_existing_config_and_a_file_that_is_not_a_network_config_is_used_then_the_result_should_be_an_error(
+    ) -> Result<()> {
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child(".safe/node/node_connection_info.config");
+        node_config_file.write_str("file that is not a network config")?;
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+
+        let result = config.add_network(
+            "new_network",
+            Some(NetworkInfo::ConnInfoLocation(String::from(
+                node_config_file.path().to_str().unwrap(),
+            ))),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "The file must contain a valid network configuration."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn given_no_pre_existing_config_and_a_url_is_used_then_a_network_should_be_saved() -> Result<()>
+    {
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child(".safe/node/node_connection_info.config");
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+        let url = "https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config";
+
+        let result = config.add_network(
+            "new_network",
+            Some(NetworkInfo::ConnInfoLocation(String::from(url))),
+        );
+
+        assert!(result.is_ok());
+        cli_config_file.assert(predicate::path::is_file());
+
+        assert_eq!(config.networks_iter().count(), 1);
+
+        let network = config.networks_iter().next().unwrap();
+        let network_name = network.0;
+        let network_info = network.1;
+        assert_eq!(network_name, "new_network");
+        match network_info {
+            NetworkInfo::NodeConfig(_) => {
+                eyre!("node config doesn't apply to this test");
+            }
+            NetworkInfo::ConnInfoLocation(url) => {
+                assert_eq!(*url, String::from(url));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn given_a_pre_existing_config_and_a_network_with_the_same_name_exists_then_the_existing_network_should_be_overwritten(
+    ) -> Result<()> {
+        // Arrange
+        // Setup existing config.
+        let serialized_config = r#"
+        {
+            "networks": {
+                "existing_network": {
+                    "NodeConfig":[
+                        [140,44,196,143,12,92,218,53,190,33,205,167,109,183,94,205,16,140,197,200,96,112,136,218,221,16,57,54,204,60,58,93,199,119,26,17,105,232,33,188,163,194,145,223,194,95,92,54],
+                        ["127.0.0.1:12000","127.0.0.2:12000"]
+                    ]
+                }
+            }
+        }"#;
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child(".safe/node/node_connection_info.config");
+        cli_config_file.write_str(serialized_config)?;
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+
+        // Setup new network info.
+        let secret_key = bls::SecretKey::random();
+        let genesis_key = hex::encode(secret_key.public_key().to_bytes());
+        let mut nodes: BTreeSet<SocketAddr> = BTreeSet::new();
+        nodes.insert(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            12000,
+        ));
+        nodes.insert(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            12000,
+        ));
+
+        // Act
+        let result = config.add_network(
+            "existing_network",
+            Some(NetworkInfo::NodeConfig((secret_key.public_key(), nodes))),
+        );
+
+        // Assert
+        // We still only have 1 network, but the node config was overwritten.
+        assert!(result.is_ok());
+        assert_eq!(config.networks_iter().count(), 1);
+
+        let network = config.networks_iter().next().unwrap();
+        let network_name = network.0;
+        let network_info = network.1;
+        assert_eq!(network_name, "existing_network");
+        match network_info {
+            NetworkInfo::NodeConfig(node_config) => {
+                assert_eq!(node_config.1.len(), 2);
+
+                let node: SocketAddr = "10.0.0.1:12000".parse().unwrap();
+                assert_eq!(node_config.1.get(&node), Some(&node));
+                let node: SocketAddr = "10.0.0.2:12000".parse().unwrap();
+                assert_eq!(node_config.1.get(&node), Some(&node));
+
+                let public_key = node_config.0;
+                assert_eq!(hex::encode(public_key.to_bytes()), genesis_key);
+            }
+            NetworkInfo::ConnInfoLocation(_) => {
+                eyre!("connection info doesn't apply to this test");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn given_a_pre_existing_config_and_a_new_node_config_is_specified_then_a_new_network_should_be_added(
+    ) -> Result<()> {
+        let serialized_config = r#"
+        {
+            "networks": {
+                "existing_network": {
+                    "NodeConfig":[
+                        [140,44,196,143,12,92,218,53,190,33,205,167,109,183,94,205,16,140,197,200,96,112,136,218,221,16,57,54,204,60,58,93,199,119,26,17,105,232,33,188,163,194,145,223,194,95,92,54],
+                        ["127.0.0.1:12000","127.0.0.2:12000"]
+                    ]
+                }
+            }
+        }"#;
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child(".safe/node/node_connection_info.config");
+        cli_config_file.write_str(serialized_config)?;
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+
+        // Setup new network info.
+        let secret_key = bls::SecretKey::random();
+        let genesis_key = hex::encode(secret_key.public_key().to_bytes());
+        let mut nodes: BTreeSet<SocketAddr> = BTreeSet::new();
+        nodes.insert(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            12000,
+        ));
+        nodes.insert(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            12000,
+        ));
+
+        // Act
+        let result = config.add_network(
+            "new_network",
+            Some(NetworkInfo::NodeConfig((secret_key.public_key(), nodes))),
+        );
+
+        // Assert
+        assert!(result.is_ok());
+        assert_eq!(config.networks_iter().count(), 2);
+
+        let network = config.networks_iter().nth(1).unwrap();
+        let network_name = network.0;
+        let network_info = network.1;
+        assert_eq!(network_name, "new_network");
+        match network_info {
+            NetworkInfo::NodeConfig(node_config) => {
+                assert_eq!(node_config.1.len(), 2);
+
+                let node: SocketAddr = "10.0.0.1:12000".parse().unwrap();
+                assert_eq!(node_config.1.get(&node), Some(&node));
+                let node: SocketAddr = "10.0.0.2:12000".parse().unwrap();
+                assert_eq!(node_config.1.get(&node), Some(&node));
+
+                let public_key = node_config.0;
+                assert_eq!(hex::encode(public_key.to_bytes()), genesis_key);
+            }
+            NetworkInfo::ConnInfoLocation(_) => {
+                eyre!("connection info doesn't apply to this test");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn given_a_pre_existing_config_and_a_conn_info_location_is_specified_then_a_new_network_should_be_added(
+    ) -> Result<()> {
+        // Arrange
+        let serialized_config = r#"
+        {
+            "networks": {
+                "existing_network": {
+                    "NodeConfig":[
+                        [140,44,196,143,12,92,218,53,190,33,205,167,109,183,94,205,16,140,197,200,96,112,136,218,221,16,57,54,204,60,58,93,199,119,26,17,105,232,33,188,163,194,145,223,194,95,92,54],
+                        ["127.0.0.1:12000","127.0.0.2:12000"]
+                    ]
+                }
+            }
+        }"#;
+        let serialized_node_config = r#"
+        [
+            "89505bbfcac9335a7639a1dca9ed027b98be46b03953e946e53695f678c827f18f6fc22dc888de2bce9078f3fce55095",
+            [
+                "127.0.0.1:33314",
+                "127.0.0.1:38932",
+                "127.0.0.1:39132",
+                "127.0.0.1:47795",
+                "127.0.0.1:49976",
+                "127.0.0.1:53018",
+                "127.0.0.1:53421",
+                "127.0.0.1:54002",
+                "127.0.0.1:54386",
+                "127.0.0.1:55890",
+                "127.0.0.1:57956"
+            ]
+        ]"#;
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child(".safe/node/node_connection_info.config");
+        let existing_node_config_file = config_dir.child("node_connection_info.config");
+        existing_node_config_file.write_str(serialized_node_config)?;
+        cli_config_file.write_str(serialized_config)?;
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+
+        // Act
+        let result = config.add_network(
+            "new_network",
+            Some(NetworkInfo::ConnInfoLocation(String::from(
+                existing_node_config_file.path().to_str().unwrap(),
+            ))),
+        );
+
+        // Assert
+        assert!(result.is_ok());
+        assert_eq!(config.networks_iter().count(), 2);
+
+        let network = config.networks_iter().nth(1).unwrap();
+        let network_name = network.0;
+        let network_info = network.1;
+        assert_eq!(network_name, "new_network");
+        match network_info {
+            NetworkInfo::NodeConfig(_) => {
+                return Err(eyre!("node config doesn't apply to this test"));
+            }
+            NetworkInfo::ConnInfoLocation(path) => {
+                assert_eq!(
+                    *path,
+                    String::from(existing_node_config_file.path().to_str().unwrap())
+                );
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/src/operations/node.rs
+++ b/src/operations/node.rs
@@ -11,7 +11,6 @@
 use super::helpers::download_and_install_github_release_asset;
 use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Result};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use sn_launch_tool::{join_with, run_with};
 use std::{
     collections::{BTreeSet, HashMap},
     fs::create_dir_all,

--- a/src/operations/node.rs
+++ b/src/operations/node.rs
@@ -11,6 +11,7 @@
 use super::helpers::download_and_install_github_release_asset;
 use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Result};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use sn_launch_tool::{join_with, run_with};
 use std::{
     collections::{BTreeSet, HashMap},
     fs::create_dir_all,

--- a/src/subcommands/config.rs
+++ b/src/subcommands/config.rs
@@ -57,14 +57,16 @@ pub enum SettingRemoveCmd {
     // },
 }
 
-pub async fn config_commander(cmd: Option<ConfigSubCommands>) -> Result<()> {
-    let mut config = Config::read()?;
+pub async fn config_commander(cmd: Option<ConfigSubCommands>, config: &mut Config) -> Result<()> {
     match cmd {
         Some(ConfigSubCommands::Add(SettingAddCmd::Network {
             network_name,
             config_location,
         })) => {
-            config.add_network(&network_name, config_location.map(NetworkInfo::ConnInfoUrl))?;
+            config.add_network(
+                &network_name,
+                config_location.map(NetworkInfo::ConnInfoLocation),
+            )?;
         }
         // Some(ConfigSubCommands::Add(SettingAddCmd::Contact { name, safeid })) => {}
         Some(ConfigSubCommands::Remove(SettingRemoveCmd::Network { network_name })) => {

--- a/src/subcommands/networks.rs
+++ b/src/subcommands/networks.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::operations::config::{read_current_node_config, Config, NetworkInfo};
+use crate::operations::config::{Config, NetworkInfo};
 use color_eyre::{eyre::bail, eyre::eyre, Result};
 use sn_api::PublicKey;
 use std::collections::BTreeSet;
@@ -39,6 +39,10 @@ pub enum NetworksSubCommands {
     Set {
         /// Network name. If the network doesn't currently exists a new one will be addded to the config, otherwise it's network connection information will be updated
         network_name: String,
+        /// The genesis key for the network you want to join. The genesis key is either generated
+        /// by the first node of the network, or it's generated before the launch and supplied to
+        /// the first node. You should use the hex string representation of the key.
+        genesis_key_hex: String,
         /// List of IP addresses (and port numbers) to set as the contact list for this new network, e.g. 127.0.0.1:12000
         addresses: Vec<SocketAddr>,
     },
@@ -50,8 +54,10 @@ pub enum NetworksSubCommands {
     },
 }
 
-pub async fn networks_commander(cmd: Option<NetworksSubCommands>) -> Result<()> {
-    let mut config = Config::read()?;
+pub async fn networks_commander(
+    cmd: Option<NetworksSubCommands>,
+    config: &mut Config,
+) -> Result<()> {
     match cmd {
         Some(NetworksSubCommands::Switch { network_name }) => {
             let msg = format!("Switching to '{}' network...", network_name);
@@ -66,7 +72,7 @@ pub async fn networks_commander(cmd: Option<NetworksSubCommands>) -> Result<()> 
         }
         Some(NetworksSubCommands::Check {}) => {
             println!("Checking current setup network connection information...");
-            let (node_config_path, current_node_config) = read_current_node_config()?;
+            let (node_config_path, current_node_config) = config.read_current_node_config()?;
             let mut matched_network = None;
             for (network_name, network_info) in config.networks_iter() {
                 if network_info.matches(&current_node_config).await {
@@ -88,8 +94,10 @@ pub async fn networks_commander(cmd: Option<NetworksSubCommands>) -> Result<()> 
             network_name,
             config_location,
         }) => {
-            let net_info =
-                config.add_network(&network_name, config_location.map(NetworkInfo::ConnInfoUrl))?;
+            let net_info = config.add_network(
+                &network_name,
+                config_location.map(NetworkInfo::ConnInfoLocation),
+            )?;
             println!(
                 "Network '{}' was added to the list. Connection information is located at '{}'",
                 network_name, net_info
@@ -97,6 +105,7 @@ pub async fn networks_commander(cmd: Option<NetworksSubCommands>) -> Result<()> 
         }
         Some(NetworksSubCommands::Set {
             network_name,
+            genesis_key_hex,
             addresses,
         }) => {
             if addresses.is_empty() {
@@ -107,13 +116,13 @@ pub async fn networks_commander(cmd: Option<NetworksSubCommands>) -> Result<()> 
                 set.insert(address);
             }
 
-            // The command will need to be expanded to provide the genesis key.
-            let genesis_key = PublicKey::bls_from_hex("8640e62cc44e75cf4fadc8ee91b74b4cf0fd2c0984fb0e3ab40f026806857d8c41f01d3725223c55b1ef87d669f5e2cc")?
+            let genesis_key = PublicKey::bls_from_hex(&genesis_key_hex)?
                 .bls()
                 .ok_or_else(|| eyre!("Unexpectedly failed to obtain (BLS) genesis key."))?;
-            let node_config = (genesis_key, set);
-            let net_info =
-                config.add_network(&network_name, Some(NetworkInfo::Addresses(node_config)))?;
+            let net_info = config.add_network(
+                &network_name,
+                Some(NetworkInfo::NodeConfig((genesis_key, set))),
+            )?;
             println!(
                 "Network '{}' was added to the list. Contacts: '{}'",
                 network_name, net_info
@@ -126,4 +135,70 @@ pub async fn networks_commander(cmd: Option<NetworksSubCommands>) -> Result<()> 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod networks_set_command {
+    use super::networks_commander;
+    use crate::operations::config::{Config, NetworkInfo};
+    use assert_fs::prelude::*;
+    use color_eyre::{eyre::eyre, Result};
+    use predicates::prelude::*;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    #[tokio::test]
+    async fn given_no_pre_existing_config_and_multiple_nodes_are_specified_then_a_network_should_be_saved(
+    ) -> Result<()> {
+        // Arrange
+        let secret_key = bls::SecretKey::random();
+        let genesis_key = hex::encode(secret_key.public_key().to_bytes());
+
+        let cmd = super::NetworksSubCommands::Set {
+            network_name: String::from("new_network"),
+            genesis_key_hex: genesis_key.clone(),
+            addresses: vec![
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 12000),
+            ],
+        };
+        let config_dir = assert_fs::TempDir::new()?;
+        let cli_config_file = config_dir.child(".safe/cli/config.json");
+        let node_config_file = config_dir.child(".safe/node/node_connection_info.config");
+        let mut config = Config::new(
+            cli_config_file.path().to_path_buf(),
+            node_config_file.path().to_path_buf(),
+        )?;
+
+        // Act
+        let result = networks_commander(Some(cmd), &mut config).await;
+
+        // Assert
+        assert!(result.is_ok());
+        cli_config_file.assert(predicate::path::is_file());
+
+        assert_eq!(config.networks_iter().count(), 1);
+
+        let (network_name, network_info) = config
+            .networks_iter()
+            .next()
+            .ok_or_else(|| eyre!("failed to obtain item from networks list"))?;
+        assert_eq!(network_name, "new_network");
+        match network_info {
+            NetworkInfo::NodeConfig((public_key, contacts)) => {
+                assert_eq!(contacts.len(), 2);
+
+                let node: SocketAddr = "127.0.0.1:12000".parse().unwrap();
+                assert_eq!(contacts.get(&node), Some(&node));
+                let node: SocketAddr = "127.0.0.2:12000".parse().unwrap();
+                assert_eq!(contacts.get(&node), Some(&node));
+
+                assert_eq!(hex::encode(public_key.to_bytes()), genesis_key);
+            }
+            NetworkInfo::ConnInfoLocation(_) => {
+                return Err(eyre!("connection info doesn't apply to this test"));
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/src/subcommands/node.rs
+++ b/src/subcommands/node.rs
@@ -7,10 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::operations::{
-    config::{read_current_node_config, Config},
-    node::*,
-};
+use crate::operations::{config::Config, node::*};
 use color_eyre::{eyre::eyre, Result};
 use sn_api::PublicKey;
 use std::{collections::BTreeSet, net::SocketAddr, path::PathBuf};
@@ -104,7 +101,7 @@ pub enum NodeSubCommands {
     },
 }
 
-pub async fn node_commander(cmd: Option<NodeSubCommands>) -> Result<()> {
+pub async fn node_commander(cmd: Option<NodeSubCommands>, config: &mut Config) -> Result<()> {
     match cmd {
         Some(NodeSubCommands::BinVersion { node_path }) => node_version(node_path),
         Some(NodeSubCommands::Install { node_path, version }) => {
@@ -126,13 +123,12 @@ pub async fn node_commander(cmd: Option<NodeSubCommands>) -> Result<()> {
         }) => {
             let network_contacts = if hard_coded_contacts.is_empty() {
                 if let Some(name) = network_name {
-                    let config = Config::read()?;
                     let msg = format!("Joining the '{}' network...", name);
                     debug!("{}", msg);
                     println!("{}", msg);
                     config.get_network_info(&name).await?
                 } else {
-                    let (_, contacts) = read_current_node_config()?;
+                    let (_, contacts) = config.read_current_node_config()?;
                     contacts
                 }
             } else {


### PR DESCRIPTION
BREAKING CHANGE: the `network set` command now has different arguments.

The `network set` command creates a new network in the configuration, that has a name and a set of nodes. Now that we require a genesis key to connect to a network, a genesis key argument was created for the command.

Test coverage has been added for this change and also to various other parts of the `Config` struct. They've been added as unit style tests rather than to the integration suite, because these commands are fairly simple and don't require a full integration test. The coverage is mostly on the `Config` struct rather than the commands, because the `add` and `set` commands basically just call `Config::add_network` and it would be quite wasteful and a bit of a maintenance issue to cover both. One test was created for the `set` command just to make sure it correctly maps its arguments onto the `add_network`.

Some refactoring took place to make testing a bit easier. The `Config::read` function was changed to a constructor that accepted both the CLI config file path and the default node config path. This gives us the ability to pass temporary file paths that are created with `assertfs`, meaning we're not working with user profile directories when the tests are run on a someone's development machine. Any command handlers that used the `Config::read` function were updated to accept a reference to a
`Config` as a parameter. The `Config` can be created in the CLI config, and that's where we can pass in the real profile directory parameters.

The `NetworkInfo` enum entries were renamed from Addresses -> NodeConfig and ConnInfoURL -> ConnInfoLocation. Since the addition of the genesis key, the network info was no longer just a set of addresses, and in terms of the connection info, that could be either a URL or a file path, so it made more sense to name that a bit more generally.