### PR TITLE
chore: upgrade sn_api to 0.37.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -3173,9 +3173,9 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "sn_api"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e06ddd5cb41ec4c712da74503e6f85fc81010b0a0a9c0f45d3135c01afa240"
+checksum = "731b117f3c77120fea630799bc45104752d5adb22218f87dd417573619d88c0e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",
@@ -3672,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f915eb6abf914599c200260efced9203504c4c37380af10cdf3b7d36970650"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ xor_name = "3.0.0"
   optional = true
 
   [dependencies.sn_api]
-  version = "~0.36"
+  version = "~0.37"
   default-features = false
   features = [ "app", "authd_client", "testing" ]
 

--- a/sn_cmd_test_utilities/Cargo.lock
+++ b/sn_cmd_test_utilities/Cargo.lock
@@ -30,17 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
-dependencies = [
- "getrandom 0.2.3",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +70,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
 name = "assert_cmd"
@@ -259,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dcd2da2e8ff774aaa0c6ac76d0fecd9d98cb5767682c101895c4858e05b833"
+checksum = "ccca1872d592bb8cdf9a48fe8f0ca1695d543511745e3790091b1816549dc93a"
 dependencies = [
  "cc",
  "glob",
@@ -313,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -324,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "byteorder"
@@ -396,15 +391,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -775,15 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exponential-backoff"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae1fe2c498e7a53a8c86b96d9dbd789c14a6a6f6886b2e4383963094b6b9895"
-dependencies = [
- "rand 0.5.6",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -1056,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
  "bytes",
  "fnv",
@@ -1078,9 +1055,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "heck"
@@ -1130,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1170,9 +1144,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.12"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1185,7 +1159,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.1",
+ "socket2 0.4.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1266,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1305,9 +1279,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1332,9 +1306,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "lock_api"
@@ -1352,15 +1326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "lru"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
-dependencies = [
- "hashbrown",
 ]
 
 [[package]]
@@ -1855,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.17.4"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3638a7715351b12c4c2a2cbdebb403ab64b7e6a9afc58664d95e6a3808b81a33"
+checksum = "1dc237722b53dbb2e80992848000559c37ff64a2dc760d716dabfbb43cac98e7"
 dependencies = [
  "backoff",
  "bincode",
@@ -1869,7 +1834,6 @@ dependencies = [
  "rcgen 0.8.13",
  "rustls",
  "serde",
- "structopt",
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
@@ -1955,19 +1919,6 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
  "winapi",
 ]
 
@@ -2320,11 +2271,12 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe_network"
-version = "0.28.4"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914ba45cfbac654d20dd33105c4dc23405e0f5f9953a00bd0b67304dee271e41"
+checksum = "8fb3e03200fb4a4365b350eeaea4126dc01e1a428aabc59b650d7903ecc8fd9d"
 dependencies = [
  "async-recursion",
+ "backoff",
  "base64 0.10.1",
  "bincode",
  "bls_dkg",
@@ -2337,15 +2289,14 @@ dependencies = [
  "dirs-next 2.0.0",
  "ed25519",
  "ed25519-dalek",
- "exponential-backoff",
  "eyre",
  "futures",
  "hex 0.3.2",
  "hex_fmt",
  "itertools 0.10.1",
  "lazy_static",
- "lru",
  "multibase 0.8.0",
+ "num_cpus",
  "qp2p",
  "rand 0.7.3",
  "rayon",
@@ -2370,6 +2321,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uhttp_uri",
+ "uluru",
  "url",
  "urlencoding",
  "xor_name",
@@ -2415,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f77e668d4b2bac50ef234ba3e6962293246347201be84c9293e14bb44ca73d9"
+checksum = "9c0a5382c7ea687ad56d44c338012637cc2312eb459a1a413e3d46ea71b847a9"
 dependencies = [
  "aes",
  "bincode",
@@ -2506,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -2585,9 +2537,9 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "sled"
-version = "0.34.6"
+version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
 dependencies = [
  "crc32fast",
  "crossbeam-epoch",
@@ -2601,18 +2553,20 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "sn_api"
-version = "0.34.1"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bincode",
+ "blsttc",
  "bytes",
  "chrono",
+ "color-eyre",
  "dirs-next 2.0.0",
  "ed25519-dalek",
  "env_logger 0.8.4",
@@ -2662,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.5.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c659a1630bac0c926701c1f53103ebc273b72edbacfc6d53f5bff4435104226b"
+checksum = "71ba1c42982966e3371a8479a501e4707704bfaf6156f58eb56ac825ca3db1f2"
 dependencies = [
  "color-eyre",
  "dirs-next 1.0.2",
@@ -2688,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
@@ -2740,9 +2694,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "a4eac2e6c19f5c3abc0c229bea31ff0b9b091c7b14990e8924b92902a303a0c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2910,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2925,9 +2879,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2942,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2984,9 +2938,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -3007,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "c4f915eb6abf914599c200260efced9203504c4c37380af10cdf3b7d36970650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3018,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -3058,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3109,6 +3063,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b600e6da808f63a440874d633b22fa04abc9c3b08212ee7292512aec62805b"
 
 [[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3140,9 +3103,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -3236,9 +3199,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3248,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3263,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3275,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3285,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3298,15 +3261,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3433,18 +3396,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sn_cmd_test_utilities/Cargo.toml
+++ b/sn_cmd_test_utilities/Cargo.toml
@@ -15,7 +15,7 @@ ctor = "~0.1"
 rand = "~0.7.3"
 serde = "1.0.123"
 serde_json = "1.0.62"
-sn_api = { version = "~0.36", default-features=false, features = ["app", "authd_client"] }
+sn_api = { version = "~0.37", default-features=false, features = ["app", "authd_client"] }
 duct = "~0.12.0"
 walkdir = "2.3.1"
 multibase = "~0.6.0"

--- a/tests/cli_cat.rs
+++ b/tests/cli_cat.rs
@@ -183,7 +183,6 @@ fn calling_safe_cat_xorurl_url_with_version() -> Result<()> {
 }
 
 #[test]
-#[ignore = "nrs"]
 fn calling_safe_cat_nrsurl_with_version() -> Result<()> {
     let tmp_dir = assert_fs::TempDir::new()?;
     let md_file1 = tmp_dir.child("test.md");

--- a/tests/cli_dog.rs
+++ b/tests/cli_dog.rs
@@ -17,7 +17,6 @@ use sn_cmd_test_utilities::util::{
 const TEST_FILE: &str = "./testdata/test.md";
 
 #[test]
-#[ignore = "nrs"]
 fn calling_safe_dog_files_container_nrsurl() -> Result<()> {
     let content = safe_cmd_stdout(["files", "put", TEST_FILE, "--json"], Some(0))?;
     let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content);
@@ -39,7 +38,6 @@ fn calling_safe_dog_files_container_nrsurl() -> Result<()> {
 }
 
 #[test]
-#[ignore = "nrs"]
 fn calling_safe_dog_files_container_nrsurl_jsoncompact() -> Result<()> {
     let content = safe_cmd_stdout(["files", "put", TEST_FILE, "--output=jsoncompact"], Some(0))?;
     let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content);
@@ -61,7 +59,6 @@ fn calling_safe_dog_files_container_nrsurl_jsoncompact() -> Result<()> {
 }
 
 #[test]
-#[ignore = "nrs"]
 fn calling_safe_dog_files_container_nrsurl_yaml() -> Result<()> {
     let content = safe_cmd_stdout(["files", "put", TEST_FILE, "--json"], Some(0))?;
     let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content);
@@ -82,7 +79,6 @@ fn calling_safe_dog_files_container_nrsurl_yaml() -> Result<()> {
 }
 
 #[test]
-#[ignore = "nrs"]
 fn calling_safe_dog_safekey_nrsurl() -> Result<()> {
     let (safekey_xorurl, _sk) = create_and_get_keys()?;
 
@@ -102,7 +98,7 @@ fn calling_safe_dog_safekey_nrsurl() -> Result<()> {
 }
 
 #[test]
-#[ignore = "nrs"]
+#[ignore = "still broken"]
 fn calling_safe_dog_nrs_url_with_subnames() -> Result<()> {
     let (safekey_xorurl, _sk) = create_and_get_keys()?;
 

--- a/tests/cli_files.rs
+++ b/tests/cli_files.rs
@@ -448,7 +448,6 @@ fn calling_files_sync_and_fetch_with_version() -> Result<()> {
 }
 
 #[test]
-#[ignore = "nrs"]
 fn calling_files_sync_and_fetch_with_nrsurl_and_nrs_update() -> Result<()> {
     let with_trailing_slash = true;
     let tmp_data_dir = assert_fs::TempDir::new()?;
@@ -512,12 +511,11 @@ fn calling_files_sync_and_fetch_with_nrsurl_and_nrs_update() -> Result<()> {
     let output = safe_cmd_stdout(["cat", &versioned_nrsurl, "--json"], Some(0))?;
     let (xorurl, files_map) = parse_files_container_output(&output);
     assert_eq!(xorurl, versioned_nrsurl);
-    assert_eq!(files_map.len(), 11);
+    assert_eq!(files_map.len(), 12);
     Ok(())
 }
 
 #[test]
-#[ignore = "nrs"]
 fn calling_files_sync_and_fetch_without_nrs_update() -> Result<()> {
     let with_trailing_slash = true;
     let tmp_data_dir = assert_fs::TempDir::new()?;
@@ -789,7 +787,6 @@ fn calling_files_ls_on_single_file() -> Result<()> {
 //
 //    expected result: We find the 2 files beneath testdata/subfolder
 #[test]
-#[ignore = "nrs"]
 fn calling_files_ls_on_nrs_with_path() -> Result<()> {
     let with_trailing_slash = true;
     let tmp_data_dir = assert_fs::TempDir::new()?;

--- a/tests/cli_files_get.rs
+++ b/tests/cli_files_get.rs
@@ -369,7 +369,6 @@ fn files_get_attempt_overwrite_sub_file_with_dir() -> Result<()> {
 /// Then it should download `src` to `dest`
 /// And the directory tree of `dest` should match the test data directory in the repository
 #[test]
-#[ignore = "nrs"]
 fn files_get_src_is_nrs_and_dest_is_unspecified() -> Result<()> {
     // Arrange
     let with_trailing_slash = true;
@@ -440,7 +439,6 @@ fn files_get_src_is_nrs_and_dest_is_unspecified() -> Result<()> {
 /// And the contents of `dest/sub2.ms` should match the contents of sub2.md in the repository
 /// testdata
 #[test]
-#[ignore = "nrs"]
 fn files_get_src_is_nrs_with_path_and_dest_is_unspecified() -> Result<()> {
     // Arrange
     let with_trailing_slash = true;
@@ -519,7 +517,6 @@ fn files_get_src_is_nrs_with_path_and_dest_is_unspecified() -> Result<()> {
 /// And the nrs link pointing to the subfolder should have been downloaded to `dest`
 /// And the contents of `dest/subfolder` should be the same as `testdata/subfolder`
 #[test]
-#[ignore = "nrs"]
 fn files_get_src_is_nrs_recursive_and_dest_not_existing() -> Result<()> {
     // Arrange
     let with_trailing_slash = false;


### PR DESCRIPTION
BREAKING CHANGE: Multimap entries for NRS will be assigned a different data type when they are created.

Updates to the latest version of sn_api and also removes the ignore attribute from NRS tests, since the new version of the API has a fix for NRS issues.